### PR TITLE
Update readme with the new cssLoaderOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ module.exports = {
       plugin: CracoLessPlugin,
       options: {
         cssLoaderOptions: {
-          modules: true,
-          localIdentName: "[local]_[hash:base64:5]"
+          modules: {localIdentName: '[local]_[hash:base64:5]'}
         }
       }
     }


### PR DESCRIPTION
https://github.com/webpack-contrib/css-loader/releases/tag/v3.0.0

`localIdentName` option was removed in favor `modules.localIdentName` option