### PR TITLE
move webpack to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "jest": "^24.9.0",
     "lint-staged": "^9.4.0",
     "prettier": "^1.15.3",
-    "react-scripts": "^3.3.0"
+    "react-scripts": "^3.3.0",
+    "webpack": "4.41.2"
   },
   "dependencies": {
     "less": "3.10.3",
-    "less-loader": "^5.0.0",
-    "webpack": "4.41.2"
+    "less-loader": "^5.0.0"
   },
   "peerDependencies": {
     "@craco/craco": "^5.5.0",


### PR DESCRIPTION
Attempt to prevent further issues with webpack-version mismatches.

Did the following tests;

Installing dependencies for this library;
- `yarn` - warnings related to `jest`, `core-js` and `typescript`. Nothing related to `less-loader` and `webpack`
- `npm install` - warnings related to `typescript`, `sass-loader` and `tsutils`. Nothing related to `less-loader` and `webpack`

Installing this library as a dependency;
- `yarn` - warnings related to `jest`, `core-js` and `typescript`. Nothing related to `less-loader` and `webpack`
- `npm` - warnings related to `typescript`, `sass-loader` and `tsutils`. Nothing related to `less-loader` and `webpack`

Tested using `yarn@1.21.1`  and `npm@6.4.1`.

