### PR TITLE
Allow CRA 4 in peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@craco/craco": "^5.5.0",
-    "react-scripts": "^3.3.0"
+    "react-scripts": "^3.3.0 || ^4.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
The plugin works well for me with Craco 5.8.0 and CRA 4. It would be nice to allow CRA 4 in peer deps.